### PR TITLE
fix client lockfile sync; skip quality gate

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -181,7 +181,7 @@ jobs:
       JAVA_VERSION: "17" # Java for SonarScanner
       # Optional: Skip quality gate check (default: false)
       HAS_SUBMODULES: ${{ needs.initialization.outputs.has_submodules == 'true' }}
-      SKIP_QUALITY_GATE: false
+      SKIP_QUALITY_GATE: true
       # Optional: Custom NuGet sources (defaults to NuGet.org + nuget.selise.biz)
       # Only specify if you need additional sources (comma-separated)
       # NUGET_SOURCES: "https://api.nuget.org/v3/index.json,https://nuget.selise.biz/nuget,https://custom-feed.com"
@@ -243,7 +243,7 @@ jobs:
       NODE_VERSION: "22"
       JAVA_VERSION: "17"
       HAS_SUBMODULES: ${{ needs.initialization.outputs.has_submodules == 'true' }}
-      SKIP_QUALITY_GATE: false
+      SKIP_QUALITY_GATE: true
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_GLOBAL }}
       SELISE_GITHUB_PAT: ${{ secrets.SELISE_GITHUB_PAT }}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3758,6 +3758,24 @@
         }
       }
     },
+    "node_modules/@seliseblocks/genesis-os/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@seliseblocks/genesis-os/node_modules/cmdk": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
@@ -3792,6 +3810,14 @@
       "engines": {
         "node": ">= 20"
       }
+    },
+    "node_modules/@seliseblocks/genesis-os/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@seliseblocks/genesis-os/node_modules/lucide-react": {
       "version": "1.27.0",
@@ -6713,6 +6739,24 @@
       "dependencies": {
         "fast-string-truncated-width": "^3.0.2"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true
     },
     "node_modules/fast-wrap-ansi": {
       "version": "0.2.2",


### PR DESCRIPTION
`npm ci` failed in `sonarqube_client` and `sca_client`: lockfile out of sync — `ajv@8.20.0`, `fast-uri@3.1.5`, `json-schema-traverse@1.0.0` missing (nested deps of `@seliseblocks/genesis-os`). Regenerated with node 22 to match CI; additive only, 44 lines. Verified `npm ci` passes in `node:22`.

`SKIP_QUALITY_GATE` set to true for both sonar jobs as requested.