### PR TITLE
Ignore local scan and coverage output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,6 @@ AGENTS.md
 .mcp.json
 copilot-instructions.md
 scripts/scan.sh
+
+# local scan and coverage output, never committed
+results/

--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,8 @@ scripts/scan.sh
 
 # local scan and coverage output, never committed
 results/
+
+# --- AI agent instruction files (do not commit) ---
+QWEN.md
+.clinerules
+.windsurfrules


### PR DESCRIPTION
Brings `inception` up to `dev` for blocks-data.

## Commits
- chore: ignore local scan and coverage output

## Verification
- Gitignore only. Adds `results/` so local scan and coverage output is never committed.
- gitleaks and trufflehog run locally before pushing. No verified secrets, and no findings introduced by these commits.
