### PR TITLE
feat: Implement Schema Index Management

### DIFF
--- a/client/app/data-gateway/components/schema-indexes/schema-index-form.test.tsx
+++ b/client/app/data-gateway/components/schema-indexes/schema-index-form.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Radix Select relies on pointer-capture and scrollIntoView APIs jsdom lacks.
+beforeAll(() => {
+  Element.prototype.hasPointerCapture ??= vi.fn(() => false) as never;
+  Element.prototype.setPointerCapture ??= vi.fn() as never;
+  Element.prototype.releasePointerCapture ??= vi.fn() as never;
+  Element.prototype.scrollIntoView ??= vi.fn() as never;
+});
+
+const createIndex = vi.fn();
+const showErrorToast = vi.fn();
+const showSuccessToast = vi.fn();
+
+vi.mock("../../hooks/use-configuration", () => ({
+  useCreateSchemaIndex: () => ({ mutateAsync: createIndex, isPending: false }),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  showErrorToast: (...a: unknown[]) => showErrorToast(...a),
+  showSuccessToast: (...a: unknown[]) => showSuccessToast(...a),
+}));
+
+import { SchemaIndexForm } from "./schema-index-form";
+
+const baseProps = {
+  schemaDefinitionItemId: "schema-1",
+  availableFields: ["email", "lastName", "age"],
+};
+
+describe("SchemaIndexForm", () => {
+  beforeEach(() => {
+    createIndex.mockReset();
+    showErrorToast.mockReset();
+    showSuccessToast.mockReset();
+  });
+
+  it("creates a single-field index and reports success", async () => {
+    const user = userEvent.setup();
+    createIndex.mockResolvedValue({ isSuccess: true, data: { acknowledged: true, itemId: "idx-1" } });
+    const onSaved = vi.fn();
+    render(<SchemaIndexForm {...baseProps} onSaved={onSaved} onCancel={vi.fn()} />);
+
+    await user.click(screen.getAllByRole("combobox")[0]);
+    await user.click(screen.getByRole("option", { name: "email" }));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save" })).toBeEnabled());
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(createIndex).toHaveBeenCalledWith({
+        schemaDefinitionItemId: "schema-1",
+        fields: [{ fieldName: "email", direction: "ASC" }],
+        isUnique: false,
+      }),
+    );
+    expect(onSaved).toHaveBeenCalled();
+    expect(showSuccessToast).toHaveBeenCalled();
+  });
+
+  it("adds a second field row for a compound index, up to the fields available", async () => {
+    const user = userEvent.setup();
+    render(<SchemaIndexForm {...baseProps} onSaved={vi.fn()} onCancel={vi.fn()} />);
+
+    expect(screen.getAllByRole("combobox").length).toBe(2); // field + direction, one row
+    await user.click(screen.getByRole("button", { name: /Add field/ }));
+    expect(screen.getAllByRole("combobox").length).toBe(4); // two rows
+  });
+
+  it("keeps Save disabled and makes no API call when no field is selected", () => {
+    render(<SchemaIndexForm {...baseProps} onSaved={vi.fn()} onCancel={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    expect(createIndex).not.toHaveBeenCalled();
+  });
+
+  it("shows the mapped server error inline and does not call onSaved", async () => {
+    const user = userEvent.setup();
+    createIndex.mockResolvedValue({ isSuccess: false, message: "UNIQUE_INDEX_CONFLICT" });
+    const onSaved = vi.fn();
+    render(<SchemaIndexForm {...baseProps} onSaved={onSaved} onCancel={vi.fn()} />);
+
+    await user.click(screen.getAllByRole("combobox")[0]);
+    await user.click(screen.getByRole("option", { name: "email" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save" })).toBeEnabled());
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "Cannot create a unique index: this field combination already has duplicate values in existing data.",
+        ),
+      ).toBeInTheDocument(),
+    );
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it("fires onCancel from the Cancel button", async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    render(<SchemaIndexForm {...baseProps} onSaved={vi.fn()} onCancel={onCancel} />);
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/client/app/data-gateway/components/schema-indexes/schema-index-form.tsx
+++ b/client/app/data-gateway/components/schema-indexes/schema-index-form.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { Button } from "@/components/ui-kits/button/button";
+import { Card } from "@/components/ui-kits/card/card";
+import { Checkbox } from "@/components/ui-kits/checkbox/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui-kits/select/select";
+import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Plus, X } from "lucide-react";
+import { useFieldArray, useForm } from "react-hook-form";
+import { z } from "zod";
+import { useCreateSchemaIndex } from "../../hooks/use-configuration";
+import type { ICreateSchemaIndexPayload } from "../../models/data-service";
+import {
+  INDEX_DIRECTION_LABELS,
+  MAX_INDEX_FIELDS,
+  mapIndexRelatedErrorMessage,
+} from "../../utils/schema-index.utils";
+
+const indexFormSchema = z.object({
+  fields: z
+    .array(
+      z.object({
+        fieldName: z.string().min(1, "Field is required"),
+        direction: z.enum(["ASC", "DESC"]),
+      }),
+    )
+    .min(1, "Select at least one field")
+    .max(MAX_INDEX_FIELDS, `An index can cover at most ${MAX_INDEX_FIELDS} fields`)
+    .refine(
+      (fields) => new Set(fields.map((f) => f.fieldName)).size === fields.length,
+      { message: "Select at least one field, with no field repeated." },
+    ),
+  isUnique: z.boolean(),
+});
+
+type IndexFormValues = z.infer<typeof indexFormSchema>;
+
+interface SchemaIndexFormProps {
+  schemaDefinitionItemId: string;
+  availableFields: string[];
+  onSaved: () => void;
+  onCancel: () => void;
+}
+
+export function SchemaIndexForm({
+  schemaDefinitionItemId,
+  availableFields,
+  onSaved,
+  onCancel,
+}: SchemaIndexFormProps) {
+  const { mutateAsync: createIndex, isPending } = useCreateSchemaIndex();
+
+  const form = useForm<IndexFormValues>({
+    resolver: zodResolver(indexFormSchema),
+    mode: "onChange",
+    defaultValues: {
+      fields: [{ fieldName: "", direction: "ASC" }],
+      isUnique: false,
+    },
+  });
+
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: "fields",
+  });
+
+  const selectedFieldNames = form.watch("fields").map((f) => f.fieldName);
+
+  const onSubmit = async (values: IndexFormValues) => {
+    const payload: ICreateSchemaIndexPayload = {
+      schemaDefinitionItemId,
+      fields: values.fields,
+      isUnique: values.isUnique,
+    };
+
+    try {
+      const res = await createIndex(payload);
+      if (res.isSuccess) {
+        showSuccessToast({ description: "Index added successfully" });
+        onSaved();
+      } else {
+        const mapped = mapIndexRelatedErrorMessage(res);
+        form.setError("root", { message: mapped ?? "Failed to create index." });
+        if (!mapped) showErrorToast({ errors: res.errors });
+      }
+    } catch (error) {
+      form.setError("root", { message: "Failed to create index." });
+      showErrorToast({ errors: error });
+    }
+  };
+
+  return (
+    <Card className="flex flex-col gap-4 p-4 shadow-none">
+      <p className="text-sm font-medium">Add index</p>
+
+      <div className="flex flex-col gap-3">
+        {fields.map((fieldRow, index) => {
+          const currentFieldName = form.watch(`fields.${index}.fieldName`);
+          const fieldOptions = availableFields.filter(
+            (name) => name === currentFieldName || !selectedFieldNames.includes(name),
+          );
+
+          return (
+            <div key={fieldRow.id} className="flex items-center gap-2">
+              <Select
+                value={currentFieldName || undefined}
+                onValueChange={(value) =>
+                  form.setValue(`fields.${index}.fieldName`, value, {
+                    shouldValidate: true,
+                  })
+                }
+              >
+                <SelectTrigger className="h-9 w-full min-w-0 flex-1">
+                  <SelectValue placeholder="Select field" />
+                </SelectTrigger>
+                <SelectContent>
+                  {fieldOptions.map((name) => (
+                    <SelectItem key={name} value={name}>
+                      {name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              <Select
+                value={form.watch(`fields.${index}.direction`)}
+                onValueChange={(value) =>
+                  form.setValue(
+                    `fields.${index}.direction`,
+                    value as "ASC" | "DESC",
+                    { shouldValidate: true },
+                  )
+                }
+              >
+                <SelectTrigger className="h-9 w-40 shrink-0">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="ASC">{INDEX_DIRECTION_LABELS.ASC}</SelectItem>
+                  <SelectItem value="DESC">{INDEX_DIRECTION_LABELS.DESC}</SelectItem>
+                </SelectContent>
+              </Select>
+
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-9 w-9 shrink-0 text-muted-foreground hover:text-destructive"
+                aria-label="Remove field"
+                disabled={fields.length === 1}
+                onClick={() => remove(index)}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          );
+        })}
+      </div>
+
+      {form.formState.errors.fields?.root?.message && (
+        <p className="text-xs text-destructive">
+          {form.formState.errors.fields.root.message}
+        </p>
+      )}
+      {form.formState.errors.fields?.message && (
+        <p className="text-xs text-destructive">
+          {form.formState.errors.fields.message}
+        </p>
+      )}
+
+      <div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="gap-2"
+          disabled={fields.length >= MAX_INDEX_FIELDS}
+          onClick={() => append({ fieldName: "", direction: "ASC" })}
+        >
+          <Plus className="h-4 w-4" />
+          Add field
+        </Button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id="index-is-unique"
+          checked={form.watch("isUnique")}
+          onCheckedChange={(checked) =>
+            form.setValue("isUnique", checked === true)
+          }
+        />
+        <label htmlFor="index-is-unique" className="cursor-pointer text-sm">
+          Unique
+        </label>
+      </div>
+
+      {form.formState.errors.root?.message && (
+        <p className="text-sm text-destructive">
+          {form.formState.errors.root.message}
+        </p>
+      )}
+
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="outline" size="sm" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          disabled={!form.formState.isValid || isPending}
+          onClick={() => void form.handleSubmit(onSubmit)()}
+        >
+          {isPending ? "Saving…" : "Save"}
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/client/app/data-gateway/components/schema-indexes/schema-indexes-tab.test.tsx
+++ b/client/app/data-gateway/components/schema-indexes/schema-indexes-tab.test.tsx
@@ -1,0 +1,173 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui-kits/tooltip/tooltip";
+
+const useSchemaIndexes = vi.fn();
+const deleteIndex = vi.fn();
+const showErrorToast = vi.fn();
+const showSuccessToast = vi.fn();
+
+vi.mock("../../hooks/use-configuration", () => ({
+  useSchemaIndexes: (...a: unknown[]) => useSchemaIndexes(...a),
+  useDeleteSchemaIndex: () => ({ mutateAsync: deleteIndex, isPending: false }),
+  useCreateSchemaIndex: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  showErrorToast: (...a: unknown[]) => showErrorToast(...a),
+  showSuccessToast: (...a: unknown[]) => showSuccessToast(...a),
+}));
+
+import { SchemaIndexesTab } from "./schema-indexes-tab";
+
+const fields = [{ name: "email" }, { name: "lastName" }, { name: "age" }];
+
+function renderTab(schemaType = 1) {
+  return render(
+    <TooltipProvider>
+      <SchemaIndexesTab
+        schemaDefinitionItemId="schema-1"
+        schemaType={schemaType}
+        fields={fields}
+      />
+    </TooltipProvider>,
+  );
+}
+
+describe("SchemaIndexesTab", () => {
+  beforeEach(() => {
+    useSchemaIndexes.mockReset();
+    deleteIndex.mockReset();
+    showErrorToast.mockReset();
+    showSuccessToast.mockReset();
+  });
+
+  it("shows the empty state and an Add index button when there are no indexes", () => {
+    useSchemaIndexes.mockReturnValue({ data: { data: { indexes: [] } }, isLoading: false });
+    renderTab();
+
+    expect(screen.getByText("No indexes yet")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Add index/ })).toBeEnabled();
+  });
+
+  it("lists existing single-field and compound indexes with direction and a Unique badge", () => {
+    useSchemaIndexes.mockReturnValue({
+      data: {
+        data: {
+          indexes: [
+            {
+              itemId: "idx-1",
+              name: "email_1",
+              isUnique: true,
+              createdDate: "2026-01-01T00:00:00Z",
+              fields: [{ fieldName: "email", direction: "ASC" }],
+            },
+            {
+              itemId: "idx-2",
+              name: "lastName_1_age_-1",
+              isUnique: false,
+              createdDate: "2026-01-01T00:00:00Z",
+              fields: [
+                { fieldName: "lastName", direction: "ASC" },
+                { fieldName: "age", direction: "DESC" },
+              ],
+            },
+          ],
+        },
+      },
+      isLoading: false,
+    });
+    renderTab();
+
+    expect(screen.getByText("email (Ascending) · Unique")).toBeInTheDocument();
+    expect(
+      screen.getByText("lastName (Ascending), age (Descending)"),
+    ).toBeInTheDocument();
+  });
+
+  it("disables Add index when the schema is Dto-type and shows an explanatory message", () => {
+    useSchemaIndexes.mockReturnValue({ data: { data: { indexes: [] } }, isLoading: false });
+    renderTab(2);
+
+    expect(screen.getByRole("button", { name: /Add index/ })).toBeDisabled();
+    expect(
+      screen.getAllByText("Indexes are only supported on Entity schemas.").length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("disables Add index once the schema already has 15 indexes", () => {
+    const indexes = Array.from({ length: 15 }, (_, i) => ({
+      itemId: `idx-${i}`,
+      name: `f${i}_1`,
+      isUnique: false,
+      createdDate: "2026-01-01T00:00:00Z",
+      fields: [{ fieldName: `f${i}`, direction: "ASC" as const }],
+    }));
+    useSchemaIndexes.mockReturnValue({ data: { data: { indexes } }, isLoading: false });
+    renderTab();
+
+    expect(screen.getByRole("button", { name: /Add index/ })).toBeDisabled();
+  });
+
+  it("deletes an index after confirmation and shows a success toast", async () => {
+    const user = userEvent.setup();
+    deleteIndex.mockResolvedValue({ isSuccess: true });
+    useSchemaIndexes.mockReturnValue({
+      data: {
+        data: {
+          indexes: [
+            {
+              itemId: "idx-1",
+              name: "email_1",
+              isUnique: false,
+              createdDate: "2026-01-01T00:00:00Z",
+              fields: [{ fieldName: "email", direction: "ASC" }],
+            },
+          ],
+        },
+      },
+      isLoading: false,
+    });
+    renderTab();
+
+    await user.click(screen.getByRole("button", { name: /Delete index/ }));
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() =>
+      expect(deleteIndex).toHaveBeenCalledWith({
+        itemId: "idx-1",
+        schemaDefinitionItemId: "schema-1",
+      }),
+    );
+    expect(showSuccessToast).toHaveBeenCalled();
+  });
+
+  it("shows an error and keeps the index listed when delete fails", async () => {
+    const user = userEvent.setup();
+    deleteIndex.mockResolvedValue({ isSuccess: false, message: "INDEX_NOT_FOUND" });
+    useSchemaIndexes.mockReturnValue({
+      data: {
+        data: {
+          indexes: [
+            {
+              itemId: "idx-1",
+              name: "email_1",
+              isUnique: false,
+              createdDate: "2026-01-01T00:00:00Z",
+              fields: [{ fieldName: "email", direction: "ASC" }],
+            },
+          ],
+        },
+      },
+      isLoading: false,
+    });
+    renderTab();
+
+    await user.click(screen.getByRole("button", { name: /Delete index/ }));
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(showErrorToast).toHaveBeenCalled());
+    expect(screen.getByText("email (Ascending)")).toBeInTheDocument();
+  });
+});

--- a/client/app/data-gateway/components/schema-indexes/schema-indexes-tab.tsx
+++ b/client/app/data-gateway/components/schema-indexes/schema-indexes-tab.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import ConfirmationModal from "@/components/confirmation-modal/confirmation-modal";
+import { Badge } from "@/components/ui-kits/badge/badge";
+import { Button } from "@/components/ui-kits/button/button";
+import { Dialog } from "@/components/ui-kits/dialog/dialog";
+import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui-kits/tooltip/tooltip";
+import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
+import { Plus, Trash } from "lucide-react";
+import { useState } from "react";
+import {
+  useDeleteSchemaIndex,
+  useSchemaIndexes,
+} from "../../hooks/use-configuration";
+import type { ISchemaIndex } from "../../models/data-service";
+import {
+  INDEX_DIRECTION_LABELS,
+  MAX_INDEXES_PER_SCHEMA,
+  mapIndexRelatedErrorMessage,
+} from "../../utils/schema-index.utils";
+import { SchemaIndexForm } from "./schema-index-form";
+
+/** Backend SchemaType.Dto — indexes are only supported on SchemaType.Entity (1). */
+const DTO_SCHEMA_TYPE = 2;
+
+interface SchemaIndexesTabProps {
+  schemaDefinitionItemId: string;
+  schemaType?: number;
+  fields: Array<{ name: string }>;
+}
+
+function formatIndexLabel(index: ISchemaIndex): string {
+  const fieldsLabel = index.fields
+    .map((f) => `${f.fieldName} (${INDEX_DIRECTION_LABELS[f.direction]})`)
+    .join(", ");
+  return index.isUnique ? `${fieldsLabel} · Unique` : fieldsLabel;
+}
+
+export function SchemaIndexesTab({
+  schemaDefinitionItemId,
+  schemaType,
+  fields,
+}: SchemaIndexesTabProps) {
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [pendingDeleteItemId, setPendingDeleteItemId] = useState<string | null>(
+    null,
+  );
+
+  const { data, isLoading } = useSchemaIndexes(schemaDefinitionItemId);
+  const { mutateAsync: deleteIndex, isPending: isDeleting } =
+    useDeleteSchemaIndex();
+
+  const indexes = data?.data?.indexes ?? [];
+  const isDto = schemaType === DTO_SCHEMA_TYPE;
+  const atLimit = indexes.length >= MAX_INDEXES_PER_SCHEMA;
+  const addDisabled = isDto || atLimit;
+  const availableFieldNames = fields.map((f) => f.name);
+
+  const handleDelete = async () => {
+    if (!pendingDeleteItemId) return;
+    try {
+      const res = await deleteIndex({
+        itemId: pendingDeleteItemId,
+        schemaDefinitionItemId,
+      });
+      if (res.isSuccess) {
+        showSuccessToast({ description: "Index deleted successfully" });
+      } else {
+        const mapped = mapIndexRelatedErrorMessage(res);
+        showErrorToast({ errors: mapped ?? res.errors ?? "Failed to delete index." });
+      }
+    } catch (error) {
+      showErrorToast({ errors: error });
+    } finally {
+      setPendingDeleteItemId(null);
+    }
+  };
+
+  const addIndexButton = (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="gap-2"
+      disabled={addDisabled}
+      onClick={() => setIsFormOpen(true)}
+    >
+      <Plus className="h-4 w-4" />
+      Add index
+    </Button>
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium text-muted-foreground">
+          {indexes.length} of {MAX_INDEXES_PER_SCHEMA} indexes
+        </p>
+
+        {!isFormOpen &&
+          (addDisabled ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>{addIndexButton}</span>
+              </TooltipTrigger>
+              <TooltipContent>
+                {isDto
+                  ? "Indexes are only supported on Entity schemas."
+                  : "Maximum of 15 indexes reached."}
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            addIndexButton
+          ))}
+      </div>
+
+      {isDto && (
+        <p className="text-sm text-muted-foreground">
+          Indexes are only supported on Entity schemas.
+        </p>
+      )}
+
+      {isFormOpen && (
+        <SchemaIndexForm
+          schemaDefinitionItemId={schemaDefinitionItemId}
+          availableFields={availableFieldNames}
+          onSaved={() => setIsFormOpen(false)}
+          onCancel={() => setIsFormOpen(false)}
+        />
+      )}
+
+      {isLoading ? (
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-12 w-full" />
+        </div>
+      ) : indexes.length === 0 ? (
+        !isFormOpen && (
+          <div className="flex items-center justify-center rounded-sm border border-dashed border-border/30 bg-muted/5 py-8 text-sm text-muted-foreground">
+            No indexes yet
+          </div>
+        )
+      ) : (
+        <div className="flex flex-col gap-2">
+          {indexes.map((index) => (
+            <div
+              key={index.itemId}
+              className="flex items-center justify-between gap-3 rounded-sm border border-border/30 bg-card/40 px-4 py-3"
+            >
+              <div className="flex min-w-0 flex-1 items-center gap-2">
+                <span className="truncate text-sm">{formatIndexLabel(index)}</span>
+                {index.isUnique && <Badge variant="secondary">Unique</Badge>}
+              </div>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
+                    aria-label={`Delete index ${index.name}`}
+                    onClick={() => setPendingDeleteItemId(index.itemId)}
+                  >
+                    <Trash className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Delete</TooltipContent>
+              </Tooltip>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Dialog
+        open={pendingDeleteItemId !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDeleteItemId(null);
+        }}
+      >
+        <ConfirmationModal
+          onCancel={() => setPendingDeleteItemId(null)}
+          onConfirm={() => void handleDelete()}
+          data={{
+            dialogTitle: "Delete index?",
+            dialogSubtitle:
+              "Are you sure you want to delete this index? This action cannot be undone.",
+            confirmButton: "Delete",
+            cancelButton: "Cancel",
+          }}
+          buttonState={{ confirm: { disable: isDeleting } }}
+        />
+      </Dialog>
+    </div>
+  );
+}

--- a/client/app/data-gateway/components/schema-structure.tsx
+++ b/client/app/data-gateway/components/schema-structure.tsx
@@ -28,6 +28,8 @@ import { sanitizeRuleSet } from "../utils/schema-access.utils";
 import SchemaAccessControlDrawer from "./schema-access-control-drawer";
 import { SchemaPreviewDrawer } from "./schema-preview-drawer";
 import { SchemaFieldValidationDrawer } from "./schema-fields-validation/schema-field-validation-drawer";
+import { SchemaIndexesTab } from "./schema-indexes/schema-indexes-tab";
+import { mapIndexRelatedErrorMessage } from "../utils/schema-index.utils";
 import { useProjectStore } from "@seliseblocks/genesis-os";
 import { InfoCard } from "./info-card";
 import {
@@ -165,7 +167,9 @@ export default function SchemaStructureTable(props: SchemaStructureTableProps) {
     projectKey,
   });
 
-  const [activeTab, setActiveTab] = useState<"attribute" | "data">("attribute");
+  const [activeTab, setActiveTab] = useState<"attribute" | "data" | "indexes">(
+    "attribute",
+  );
 
   useEffect(() => {
     setActiveTab("attribute");
@@ -372,7 +376,11 @@ export default function SchemaStructureTable(props: SchemaStructureTableProps) {
         block: "start",
       });
     } else {
-      showErrorToast({ errors: res.errors });
+      // A field the user tried to delete is referenced by an existing index (Phase 1's
+      // FIELD_USED_BY_INDEX guard) surfaces via `message`, not `errors` — map it explicitly
+      // so this doesn't fall through to a generic "unexpected error" toast.
+      const mapped = mapIndexRelatedErrorMessage(res);
+      showErrorToast({ errors: mapped ?? res.errors });
     }
   };
 
@@ -603,6 +611,17 @@ export default function SchemaStructureTable(props: SchemaStructureTableProps) {
                 schemaName={schemaDetails.schemaName}
                 fields={templateFields}
                 previewData={previewData}
+              />
+            </div>
+          )}
+
+          {/* Indexes Tab */}
+          {activeTab === "indexes" && (
+            <div className="mt-4 min-h-0 flex-1 overflow-auto px-0">
+              <SchemaIndexesTab
+                schemaDefinitionItemId={schemaDetails.id}
+                schemaType={schemaType}
+                fields={schemaDetails.fields}
               />
             </div>
           )}

--- a/client/app/data-gateway/components/schema-structure/schema-structure-header.tsx
+++ b/client/app/data-gateway/components/schema-structure/schema-structure-header.tsx
@@ -25,8 +25,8 @@ interface SchemaStructureHeaderProps {
   schemaType?: number;
   templateFields: Array<{ name: string; type?: string; isArray: boolean }>;
   previewData: Record<string, unknown>;
-  activeTab: "attribute" | "data";
-  onTabChange: (tab: "attribute" | "data") => void;
+  activeTab: "attribute" | "data" | "indexes";
+  onTabChange: (tab: "attribute" | "data" | "indexes") => void;
   onEditToggle: () => void;
   // onBulkManageAccess: () => void;
   onBulkDuplicate: () => void;
@@ -73,7 +73,10 @@ export function SchemaStructureHeader({
   const isShowPreviewButton = fieldLength > 0;
 
   const SchemaTabs = (
-    <Tabs value={activeTab} onValueChange={(v) => onTabChange(v as "attribute" | "data")}>
+    <Tabs
+      value={activeTab}
+      onValueChange={(v) => onTabChange(v as "attribute" | "data" | "indexes")}
+    >
       <TabsList className="h-8 gap-1 bg-transparent p-0">
         <TabsTrigger
           value="attribute"
@@ -89,6 +92,12 @@ export function SchemaStructureHeader({
             Data
           </TabsTrigger>
         )}
+        <TabsTrigger
+          value="indexes"
+          className="h-8 rounded-none border-b-2 border-transparent px-4 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+        >
+          Indexes
+        </TabsTrigger>
       </TabsList>
     </Tabs>
   );

--- a/client/app/data-gateway/constants/endpoint.constant.ts
+++ b/client/app/data-gateway/constants/endpoint.constant.ts
@@ -22,6 +22,13 @@ export const SCHEMA_ENDPOINTS = {
   UNADAPTED_CHANGE_LOGS: `${API_BASES.UDS}${SCHEMAS_SUBPATH}/unadapted-change-logs`,
 } as const;
 
+// ─── Schema Index endpoints ───────────────────────────────────────────────────
+// Served by the backend's dedicated SchemaIndexController (route "schemas/indexes").
+
+export const SCHEMA_INDEX_ENDPOINTS = {
+  BASE: `${API_BASES.UDS}${SCHEMAS_SUBPATH}/indexes`,
+} as const;
+
 // ─── Data Access endpoints ────────────────────────────────────────────────────
 
 const DATA_ACCESS_SUBPATH = "/data-access";

--- a/client/app/data-gateway/hooks/use-configuration.ts
+++ b/client/app/data-gateway/hooks/use-configuration.ts
@@ -8,10 +8,12 @@ import {
 } from "graphql";
 import {
   ICreateSchemaFieldValidationPayload,
+  ICreateSchemaIndexPayload,
   ICreateSchemaPayload,
   IDeleteMockDataPayload,
   IDeletePolicyPayload,
   IDeleteSchemaFieldValidationPayload,
+  IDeleteSchemaIndexPayload,
   IExecuteGraphQLPayload,
   IGetSchemaFieldValidationPayload,
   IGetSchemaListPayload,
@@ -657,6 +659,45 @@ export const useRawIntrospectionQuery = (options: {
     staleTime: Number.POSITIVE_INFINITY,
     gcTime: 30 * 60 * 1000,
     retry: 1,
+  });
+};
+
+export const useSchemaIndexes = (
+  schemaDefinitionItemId: string,
+  options?: { enabled?: boolean },
+) => {
+  return useQuery({
+    queryKey: ["schema-indexes", schemaDefinitionItemId],
+    queryFn: () => configurationService.getSchemaIndexes(schemaDefinitionItemId),
+    enabled: !!schemaDefinitionItemId && (options?.enabled ?? true),
+  });
+};
+
+export const useCreateSchemaIndex = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: ICreateSchemaIndexPayload) =>
+      configurationService.createSchemaIndex(payload),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["schema-indexes", variables.schemaDefinitionItemId],
+      });
+    },
+  });
+};
+
+export const useDeleteSchemaIndex = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: IDeleteSchemaIndexPayload) =>
+      configurationService.deleteSchemaIndex(payload),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["schema-indexes", variables.schemaDefinitionItemId],
+      });
+    },
   });
 };
 

--- a/client/app/data-gateway/models/data-service.ts
+++ b/client/app/data-gateway/models/data-service.ts
@@ -437,6 +437,50 @@ export interface IDeleteSchemaFieldValidationPayload {
   projectKey: string;
 }
 
+// ── Schema Indexes ────────────────────────────────────────────────────────
+
+/** Wire form of the backend's SortDirection enum (JsonStringEnumConverter → member name). */
+export type IndexDirection = "ASC" | "DESC";
+
+export interface IIndexFieldPayload {
+  fieldName: string;
+  direction: IndexDirection;
+}
+
+export interface ISchemaIndex {
+  itemId: string;
+  name: string;
+  fields: IIndexFieldPayload[];
+  isUnique: boolean;
+  createdDate: string;
+}
+
+export interface IGetSchemaIndexesResponse {
+  isSuccess: boolean;
+  message?: string | null;
+  errors?: unknown;
+  data: { indexes: ISchemaIndex[] } | null;
+}
+
+export interface ICreateSchemaIndexPayload {
+  schemaDefinitionItemId: string;
+  fields: IIndexFieldPayload[];
+  isUnique: boolean;
+}
+
+export interface ISchemaIndexActionResponse {
+  isSuccess: boolean;
+  message?: string | null;
+  errors?: unknown;
+  data: { acknowledged: boolean; itemId: string } | null;
+}
+
+export interface IDeleteSchemaIndexPayload {
+  itemId: string;
+  /** Not sent to the API — used only to invalidate the right ["schema-indexes", id] query. */
+  schemaDefinitionItemId: string;
+}
+
 
 // ── Schema Export ──────────────────────────────────────────────────────────
 /** Mirrors backend `SchemaExportOption`. Value `All` (3) includes both optional sections together. */

--- a/client/app/data-gateway/services/configuration.service.ts
+++ b/client/app/data-gateway/services/configuration.service.ts
@@ -9,11 +9,13 @@ import {
   DATA_VALIDATION_REGEX_ENDPOINTS,
   GATEWAY_ENDPOINTS,
   SCHEMA_ENDPOINTS,
+  SCHEMA_INDEX_ENDPOINTS,
 } from "../constants/endpoint.constant";
 import {
   ICreatePolicyPayload,
   ICreatePolicyResponse,
   ICreateSchemaFieldValidationPayload,
+  ICreateSchemaIndexPayload,
   ICreateSchemaPayload,
   ICreateSchemaResponse,
   IDataServiceConfiguration,
@@ -24,16 +26,19 @@ import {
   IDeletePolicyPayload,
   IDeletePolicyResponse,
   IDeleteSchemaFieldValidationPayload,
+  IDeleteSchemaIndexPayload,
   IGetPolicyResponse,
   IGetSchemaDetailsResponse,
   IGetSchemaFieldValidationPayload,
   IGetSchemaFieldValidationResponse,
+  IGetSchemaIndexesResponse,
   IGetSchemaListPayload,
   IGetSchemaListResponse,
   IGetUnAdaptedChangeLogsPayload,
   IMockDataResponse,
   ISchemaExportPayload,
   ISchemaExportResponse,
+  ISchemaIndexActionResponse,
   ISetDataAccessPayload,
   ISetDataAccessResponse,
   ISetRowColumnPermissionPayload,
@@ -229,6 +234,26 @@ class ConfigurationService {
     const url = `${API_BASES.UDS}/schema-exchange/import`;
     return http.post(url, payload);
   };
+
+  getSchemaIndexes(
+    schemaDefinitionItemId: string,
+  ): Promise<IGetSchemaIndexesResponse> {
+    const params = new URLSearchParams({ schemaDefinitionItemId });
+    return http.get(`${SCHEMA_INDEX_ENDPOINTS.BASE}?${params.toString()}`);
+  }
+
+  createSchemaIndex(
+    payload: ICreateSchemaIndexPayload,
+  ): Promise<ISchemaIndexActionResponse> {
+    return http.post(SCHEMA_INDEX_ENDPOINTS.BASE, payload);
+  }
+
+  deleteSchemaIndex(
+    payload: IDeleteSchemaIndexPayload,
+  ): Promise<ISchemaIndexActionResponse> {
+    const params = new URLSearchParams({ itemId: payload.itemId });
+    return http.delete(`${SCHEMA_INDEX_ENDPOINTS.BASE}?${params.toString()}`);
+  }
 }
 
 export const configurationService = new ConfigurationService();

--- a/client/app/data-gateway/utils/schema-index.utils.test.ts
+++ b/client/app/data-gateway/utils/schema-index.utils.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { mapIndexRelatedErrorMessage } from "./schema-index.utils";
+
+describe("mapIndexRelatedErrorMessage", () => {
+  it("maps a bare error code from message", () => {
+    expect(mapIndexRelatedErrorMessage({ message: "SCHEMA_NOT_FOUND" })).toBe(
+      "Schema not found.",
+    );
+    expect(
+      mapIndexRelatedErrorMessage({ message: "SCHEMA_TYPE_NOT_INDEXABLE" }),
+    ).toBe("Indexes are only supported on Entity schemas.");
+    expect(mapIndexRelatedErrorMessage({ message: "INDEX_LIMIT_REACHED" })).toBe(
+      "This schema already has the maximum of 15 indexes.",
+    );
+    expect(mapIndexRelatedErrorMessage({ message: "INDEX_ALREADY_EXISTS" })).toBe(
+      "An index with this exact field combination already exists.",
+    );
+    expect(mapIndexRelatedErrorMessage({ message: "UNIQUE_INDEX_CONFLICT" })).toBe(
+      "Cannot create a unique index: this field combination already has duplicate values in existing data.",
+    );
+    expect(mapIndexRelatedErrorMessage({ message: "INDEX_NOT_FOUND" })).toBe(
+      "This index no longer exists.",
+    );
+  });
+
+  it("maps a code with a ': detail' suffix, using the detail in the message", () => {
+    expect(
+      mapIndexRelatedErrorMessage({ message: "FIELD_NOT_INDEXABLE: age" }),
+    ).toBe("Field 'age' cannot be indexed.");
+    expect(
+      mapIndexRelatedErrorMessage({ message: "FIELD_USED_BY_INDEX: email_1" }),
+    ).toBe("This field is used by index 'email_1' and cannot be deleted.");
+  });
+
+  it("falls back to a generic message when the code has no detail", () => {
+    expect(mapIndexRelatedErrorMessage({ message: "FIELD_NOT_INDEXABLE" })).toBe(
+      "One or more selected fields cannot be indexed.",
+    );
+    expect(mapIndexRelatedErrorMessage({ message: "FIELD_USED_BY_INDEX" })).toBe(
+      "This field is used by an existing index and cannot be deleted.",
+    );
+  });
+
+  it("falls back to the first FluentValidation error's errorMessage when message is absent", () => {
+    expect(
+      mapIndexRelatedErrorMessage({
+        errors: [{ errorMessage: "INVALID_INDEX_FIELDS" }],
+      }),
+    ).toBe("Select at least one field, with no field repeated.");
+  });
+
+  it("returns null for an unrecognized code, so callers can fall back to generic handling", () => {
+    expect(mapIndexRelatedErrorMessage({ message: "Schema not found" })).toBeNull();
+    expect(mapIndexRelatedErrorMessage({})).toBeNull();
+    expect(mapIndexRelatedErrorMessage({ errors: ["plain string error"] })).toBeNull();
+  });
+});

--- a/client/app/data-gateway/utils/schema-index.utils.ts
+++ b/client/app/data-gateway/utils/schema-index.utils.ts
@@ -1,0 +1,63 @@
+import type { IndexDirection } from "../models/data-service";
+
+/**
+ * The backend returns a bare error code (optionally with a ": <detail>" suffix) either as
+ * ServiceResponse.message (business-rule errors) or as the first FluentValidation failure's
+ * errorMessage (request-shape errors). Both are normalized here to one lookup.
+ */
+interface IndexErrorSource {
+  message?: string | null;
+  errors?: unknown;
+}
+
+const INDEX_ERROR_MESSAGES: Record<string, (detail: string) => string> = {
+  SCHEMA_NOT_FOUND: () => "Schema not found.",
+  SCHEMA_TYPE_NOT_INDEXABLE: () => "Indexes are only supported on Entity schemas.",
+  FIELD_NOT_INDEXABLE: (detail) =>
+    detail ? `Field '${detail}' cannot be indexed.` : "One or more selected fields cannot be indexed.",
+  INVALID_INDEX_FIELDS: () => "Select at least one field, with no field repeated.",
+  INDEX_ALREADY_EXISTS: () => "An index with this exact field combination already exists.",
+  INDEX_LIMIT_REACHED: () => "This schema already has the maximum of 15 indexes.",
+  UNIQUE_INDEX_CONFLICT: () =>
+    "Cannot create a unique index: this field combination already has duplicate values in existing data.",
+  INDEX_NOT_FOUND: () => "This index no longer exists.",
+  FIELD_USED_BY_INDEX: (detail) =>
+    detail
+      ? `This field is used by index '${detail}' and cannot be deleted.`
+      : "This field is used by an existing index and cannot be deleted.",
+};
+
+const extractRawCode = (res: IndexErrorSource): string | null => {
+  if (typeof res.message === "string" && res.message.trim()) return res.message;
+  if (Array.isArray(res.errors) && res.errors.length > 0) {
+    const first = res.errors[0] as { errorMessage?: unknown } | string;
+    if (typeof first === "string") return first;
+    if (typeof first?.errorMessage === "string") return first.errorMessage;
+  }
+  return null;
+};
+
+/**
+ * Maps a Phase 1 backend error code (e.g. "FIELD_NOT_INDEXABLE: age, tags") to a human-readable
+ * message. Returns null when the response doesn't carry a recognized index-related code, so the
+ * caller can fall back to its own generic error handling.
+ */
+export function mapIndexRelatedErrorMessage(res: IndexErrorSource): string | null {
+  const raw = extractRawCode(res);
+  if (!raw) return null;
+
+  const separatorIndex = raw.indexOf(":");
+  const code = (separatorIndex === -1 ? raw : raw.slice(0, separatorIndex)).trim();
+  const detail = separatorIndex === -1 ? "" : raw.slice(separatorIndex + 1).trim();
+
+  const toMessage = INDEX_ERROR_MESSAGES[code];
+  return toMessage ? toMessage(detail) : null;
+}
+
+export const INDEX_DIRECTION_LABELS: Record<IndexDirection, string> = {
+  ASC: "Ascending",
+  DESC: "Descending",
+};
+
+export const MAX_INDEX_FIELDS = 10;
+export const MAX_INDEXES_PER_SCHEMA = 15;

--- a/server/Api/Blocks.Data.Api.xml
+++ b/server/Api/Blocks.Data.Api.xml
@@ -336,6 +336,36 @@
             <param name="id">The unique identifier of the schema definition to delete.</param>
             <returns>Returns a success response if the schema is deleted, or an error message if the operation fails.</returns>
         </member>
+        <member name="T:Api.Controllers.SchemaIndexController">
+            <summary>
+            SchemaIndexController manages MongoDB indexes defined on a schema's data collection:
+            creating, listing, and deleting single-field or compound indexes.
+            </summary>
+        </member>
+        <member name="M:Api.Controllers.SchemaIndexController.#ctor(DataGateway.DomainService.Services.ISchemaIndexService)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Api.Controllers.SchemaIndexController"/> class.
+            </summary>
+            <param name="schemaIndexService"></param>
+        </member>
+        <member name="M:Api.Controllers.SchemaIndexController.GetSchemaIndexes(System.String)">
+            <summary>
+            Retrieves every index defined on a schema.
+            </summary>
+            <param name="schemaDefinitionItemId">The unique identifier of the schema definition.</param>
+        </member>
+        <member name="M:Api.Controllers.SchemaIndexController.CreateSchemaIndex(DataGateway.DomainService.Models.CreateSchemaIndexRequest)">
+            <summary>
+            Creates a new index (single-field or compound) on an Entity-type schema's data collection.
+            </summary>
+            <param name="request">SchemaDefinitionItemId, ordered Fields (FieldName, Direction), and IsUnique.</param>
+        </member>
+        <member name="M:Api.Controllers.SchemaIndexController.DeleteSchemaIndex(System.String)">
+            <summary>
+            Deletes a schema index by its unique ID. This drops the underlying MongoDB index as well.
+            </summary>
+            <param name="itemId">The unique identifier of the schema index to delete.</param>
+        </member>
         <member name="T:Api.Controllers.DirectoryController">
              <summary>
              Directory operations: create, read, list children, rename, move and delete.

--- a/server/Api/Controllers/DataGateway/SchemaController.cs
+++ b/server/Api/Controllers/DataGateway/SchemaController.cs
@@ -137,7 +137,6 @@ namespace Api.Controllers
             return StatusCode(response.HttpStatusCode, response);
         }
 
-
         #endregion
 
         #region Post
@@ -188,7 +187,6 @@ namespace Api.Controllers
             var response = await _schemaService.SaveFieldDefinitionAsync(request);
             return StatusCode(response.HttpStatusCode, response);
         }
-
 
         #endregion
 

--- a/server/Api/Controllers/DataGateway/SchemaIndexController.cs
+++ b/server/Api/Controllers/DataGateway/SchemaIndexController.cs
@@ -1,0 +1,81 @@
+using Blocks.Genesis;
+using DataGateway.DomainService.Models;
+using DataGateway.DomainService.Models.Responses;
+using DataGateway.DomainService.Services;
+using Microsoft.AspNetCore.Mvc;
+using System.Net;
+
+namespace Api.Controllers
+{
+    /// <summary>
+    /// SchemaIndexController manages MongoDB indexes defined on a schema's data collection:
+    /// creating, listing, and deleting single-field or compound indexes.
+    /// </summary>
+    [Route("schemas/indexes")]
+    [ApiController]
+    public class SchemaIndexController : ControllerBase
+    {
+        private readonly ISchemaIndexService _schemaIndexService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SchemaIndexController"/> class.
+        /// </summary>
+        /// <param name="schemaIndexService"></param>
+        public SchemaIndexController(ISchemaIndexService schemaIndexService)
+        {
+            _schemaIndexService = schemaIndexService;
+        }
+
+        /// <summary>
+        /// Retrieves every index defined on a schema.
+        /// </summary>
+        /// <param name="schemaDefinitionItemId">The unique identifier of the schema definition.</param>
+        [HttpGet]
+        [ProtectedEndPoint("blocks-data::schema::get-schema-indexes")]
+        [ProducesResponseType(typeof(ServiceResponse<SchemaIndexListResponse>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetSchemaIndexes([FromQuery] string schemaDefinitionItemId)
+        {
+            if (string.IsNullOrWhiteSpace(schemaDefinitionItemId))
+                return StatusCode((int)HttpStatusCode.BadRequest, new { Message = "INVALID_SCHEMA_ID" });
+
+            var response = await _schemaIndexService.GetIndexesAsync(schemaDefinitionItemId);
+            return StatusCode(response.HttpStatusCode, response);
+        }
+
+        /// <summary>
+        /// Creates a new index (single-field or compound) on an Entity-type schema's data collection.
+        /// </summary>
+        /// <param name="request">SchemaDefinitionItemId, ordered Fields (FieldName, Direction), and IsUnique.</param>
+        [HttpPost]
+        [ProtectedEndPoint("blocks-data::schema::create-schema-index")]
+        [ProducesResponseType(typeof(ServiceResponse<ActionResponse>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
+        public async Task<IActionResult> CreateSchemaIndex([FromBody] CreateSchemaIndexRequest request)
+        {
+            var response = await _schemaIndexService.CreateIndexAsync(request);
+            return StatusCode(response.HttpStatusCode, response);
+        }
+
+        /// <summary>
+        /// Deletes a schema index by its unique ID. This drops the underlying MongoDB index as well.
+        /// </summary>
+        /// <param name="itemId">The unique identifier of the schema index to delete.</param>
+        [HttpDelete]
+        [ProtectedEndPoint("blocks-data::schema::delete-schema-index")]
+        [ProducesResponseType(typeof(ServiceResponse<ActionResponse>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> DeleteSchemaIndex([FromQuery] string itemId)
+        {
+            if (string.IsNullOrWhiteSpace(itemId))
+                return StatusCode((int)HttpStatusCode.BadRequest, new { Message = "INVALID_INDEX_ID" });
+
+            var response = await _schemaIndexService.DeleteIndexAsync(itemId);
+            return StatusCode(response.HttpStatusCode, response);
+        }
+    }
+}

--- a/server/DataGateway.DomainService/Entities/SchemaIndexDefinition.cs
+++ b/server/DataGateway.DomainService/Entities/SchemaIndexDefinition.cs
@@ -1,0 +1,23 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace DataGateway.DomainService.Entities;
+
+[BsonIgnoreExtraElements]
+public class SchemaIndexDefinition : GraphQlBaseEntity
+{
+    public string SchemaDefinitionItemId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public List<IndexFieldSpec> Fields { get; set; } = new List<IndexFieldSpec>();
+    public bool IsUnique { get; set; }
+}
+
+[BsonIgnoreExtraElements]
+public class IndexFieldSpec
+{
+    public string FieldName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// MongoDB sort direction for this key within the index: 1 (ascending) or -1 (descending).
+    /// </summary>
+    public int Direction { get; set; } = 1;
+}

--- a/server/DataGateway.DomainService/Models/CreateSchemaIndexRequest.cs
+++ b/server/DataGateway.DomainService/Models/CreateSchemaIndexRequest.cs
@@ -1,0 +1,14 @@
+namespace DataGateway.DomainService.Models;
+
+public class CreateSchemaIndexRequest
+{
+    public string SchemaDefinitionItemId { get; set; } = string.Empty;
+    public List<IndexFieldRequest> Fields { get; set; } = [];
+    public bool IsUnique { get; set; }
+}
+
+public class IndexFieldRequest
+{
+    public string FieldName { get; set; } = string.Empty;
+    public SortDirection Direction { get; set; } = SortDirection.ASC;
+}

--- a/server/DataGateway.DomainService/Models/Responses/SchemaIndexResponse.cs
+++ b/server/DataGateway.DomainService/Models/Responses/SchemaIndexResponse.cs
@@ -1,0 +1,23 @@
+using DataGateway.DomainService.Models;
+
+namespace DataGateway.DomainService.Models.Responses;
+
+public class SchemaIndexResponse
+{
+    public string ItemId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public List<IndexFieldResponse> Fields { get; set; } = [];
+    public bool IsUnique { get; set; }
+    public DateTime CreatedDate { get; set; }
+}
+
+public class IndexFieldResponse
+{
+    public string FieldName { get; set; } = string.Empty;
+    public SortDirection Direction { get; set; }
+}
+
+public class SchemaIndexListResponse
+{
+    public List<SchemaIndexResponse> Indexes { get; set; } = [];
+}

--- a/server/DataGateway.DomainService/Models/ServiceEnums.cs
+++ b/server/DataGateway.DomainService/Models/ServiceEnums.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace DataGateway.DomainService.Models;
 
 public enum SchemaType
@@ -28,7 +30,9 @@ public enum SchemaChangeType
     SchemaPolicyUpdate,
     SchemaFieldValidationCreate,
     SchemaFieldValidationUpdate,
-    SchemaFieldValidationDelete
+    SchemaFieldValidationDelete,
+    SchemaIndexCreate,
+    SchemaIndexDelete
 }
 
 public enum SchemaAccessLevel
@@ -125,6 +129,7 @@ public enum PolicyType
 /// <summary>
 /// Sort direction for typed order clauses.
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum SortDirection
 {
     ASC,

--- a/server/DataGateway.DomainService/Repositories/DbRepository.cs
+++ b/server/DataGateway.DomainService/Repositories/DbRepository.cs
@@ -376,6 +376,38 @@ public class DbRepository : IDbRepository
     }
     #endregion
 
+    #region Index
+    public async Task<ActionResponse> CreateIndexAsync(string collectionName, List<(string FieldName, int Direction)> keys, bool isUnique, string indexName, string databaseName = "")
+    {
+        SetDatabase(databaseName);
+        var collection = _database.GetCollection<BsonDocument>(collectionName);
+
+        var keysBuilder = Builders<BsonDocument>.IndexKeys;
+        IndexKeysDefinition<BsonDocument> indexKeys = keys[0].Direction < 0
+            ? keysBuilder.Descending(keys[0].FieldName)
+            : keysBuilder.Ascending(keys[0].FieldName);
+        for (var i = 1; i < keys.Count; i++)
+        {
+            indexKeys = keys[i].Direction < 0
+                ? indexKeys.Descending(keys[i].FieldName)
+                : indexKeys.Ascending(keys[i].FieldName);
+        }
+
+        var model = new CreateIndexModel<BsonDocument>(indexKeys, new CreateIndexOptions { Name = indexName, Unique = isUnique });
+        await collection.Indexes.CreateOneAsync(model);
+
+        return new ActionResponse { Acknowledged = true, ItemId = indexName };
+    }
+
+    public async Task<ActionResponse> DropIndexAsync(string collectionName, string indexName, string databaseName = "")
+    {
+        SetDatabase(databaseName);
+        var collection = _database.GetCollection<BsonDocument>(collectionName);
+        await collection.Indexes.DropOneAsync(indexName);
+        return new ActionResponse { Acknowledged = true, ItemId = indexName };
+    }
+    #endregion
+
     #region Private Methods
     private DbRepository SetDatabase(string databaseName)
     {

--- a/server/DataGateway.DomainService/Repositories/IDbRepository.cs
+++ b/server/DataGateway.DomainService/Repositories/IDbRepository.cs
@@ -85,4 +85,17 @@ public interface IDbRepository
     Task<ActionResponse> UpsertAsync(string collectionName, BsonDocument data, string databaseName = "");
     Task<ActionResponse> UpsertManyAsync<T>(List<T> data, string databaseName = "") where T : GraphQlBaseEntity;
     #endregion
+    #region Index
+    /// <summary>
+    /// Creates a MongoDB index on an arbitrary, user-defined data collection (not a
+    /// GraphQlBaseEntity-typed collection), for an ordered list of field name/direction pairs.
+    /// Direction is the raw Mongo sort value: 1 for ascending, -1 for descending.
+    /// </summary>
+    Task<ActionResponse> CreateIndexAsync(string collectionName, List<(string FieldName, int Direction)> keys, bool isUnique, string indexName, string databaseName = "");
+
+    /// <summary>
+    /// Drops a previously created index by name from the given data collection.
+    /// </summary>
+    Task<ActionResponse> DropIndexAsync(string collectionName, string indexName, string databaseName = "");
+    #endregion
 }

--- a/server/DataGateway.DomainService/ServiceRegistry.cs
+++ b/server/DataGateway.DomainService/ServiceRegistry.cs
@@ -38,6 +38,7 @@ public static class ServiceRegistry
         serviceCollection.AddScoped<IDataGatewayConfigurationService, DataGatewayConfigurationService>();
         serviceCollection.AddScoped<SchemaDefinitionReferenceHelper>();
         serviceCollection.AddScoped<ISchemaDefinitionService, SchemaDefinitionService>();
+        serviceCollection.AddScoped<ISchemaIndexService, SchemaIndexService>();
         serviceCollection.AddScoped<ISchemaChangeLogService, SchemaChangeLogService>();
         serviceCollection.AddScoped<IDataAccessService, DataAccessService>();
         serviceCollection.AddScoped<IMockDataService, MockDataService>();

--- a/server/DataGateway.DomainService/Services/ISchemaIndexService.cs
+++ b/server/DataGateway.DomainService/Services/ISchemaIndexService.cs
@@ -1,0 +1,11 @@
+using DataGateway.DomainService.Models;
+using DataGateway.DomainService.Models.Responses;
+
+namespace DataGateway.DomainService.Services;
+
+public interface ISchemaIndexService
+{
+    Task<ServiceResponse<ActionResponse>> CreateIndexAsync(CreateSchemaIndexRequest request);
+    Task<ServiceResponse<SchemaIndexListResponse>> GetIndexesAsync(string schemaDefinitionItemId);
+    Task<ServiceResponse<ActionResponse>> DeleteIndexAsync(string itemId);
+}

--- a/server/DataGateway.DomainService/Services/Implementations/SchemaDefinitionService.cs
+++ b/server/DataGateway.DomainService/Services/Implementations/SchemaDefinitionService.cs
@@ -97,7 +97,20 @@ public class SchemaDefinitionService : ISchemaDefinitionService
             return SchemaNotFoundResponse();
 
         if (request.DeletableFieldNames?.Length > 0)
+        {
+            var indexFilter = new BsonDocument(nameof(SchemaIndexDefinition.SchemaDefinitionItemId), schema.ItemId);
+            var indexes = await _repository.GetItemsAsync<SchemaIndexDefinition>(indexFilter, null, null, 0, 1000);
+            var blockingIndexNames = indexes
+                .Where(i => i.Fields.Any(f => request.DeletableFieldNames.Contains(f.FieldName)))
+                .Select(i => i.Name)
+                .ToList();
+            if (blockingIndexNames.Count > 0)
+                return new ServiceResponse<ActionResponse>()
+                    .SetErrorMessage($"FIELD_USED_BY_INDEX: {string.Join(", ", blockingIndexNames)}")
+                    .SetHttpStatusCode(400);
+
             schema.Fields = schema.Fields.Where(f => !request.DeletableFieldNames.Contains(f.Name)).ToList();
+        }
 
         foreach (var field in request.Fields)
         {

--- a/server/DataGateway.DomainService/Services/Implementations/SchemaIndexService.cs
+++ b/server/DataGateway.DomainService/Services/Implementations/SchemaIndexService.cs
@@ -1,0 +1,150 @@
+using DataGateway.DomainService.Entities;
+using DataGateway.DomainService.Helpers;
+using DataGateway.DomainService.Models;
+using DataGateway.DomainService.Models.Responses;
+using DataGateway.DomainService.Repositories;
+using DataGateway.DomainService.Validators;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using SortDirection = DataGateway.DomainService.Models.SortDirection;
+
+namespace DataGateway.DomainService.Services;
+
+/// <summary>
+/// Manages MongoDB indexes defined on an Entity-type schema's data collection.
+/// </summary>
+public class SchemaIndexService : ISchemaIndexService
+{
+    private const int MaxIndexesPerSchema = 15;
+
+    private readonly IDbRepository _repository;
+    private readonly IRequestValidator _requestValidator;
+    private readonly ISchemaChangeLogService _schemaChangeLogService;
+
+    public SchemaIndexService(
+        IDbRepository repository,
+        IRequestValidator requestValidator,
+        ISchemaChangeLogService schemaChangeLogService)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _requestValidator = requestValidator ?? throw new ArgumentNullException(nameof(requestValidator));
+        _schemaChangeLogService = schemaChangeLogService ?? throw new ArgumentNullException(nameof(schemaChangeLogService));
+    }
+
+    public async Task<ServiceResponse<ActionResponse>> CreateIndexAsync(CreateSchemaIndexRequest request)
+    {
+        var validationResult = await _requestValidator.ValidateAsync(request);
+        if (!validationResult.IsValid)
+            return new ServiceResponse<ActionResponse>().SetErrors(validationResult.Errors);
+
+        var schema = await _repository.GetItemAsync<SchemaDefinition>(request.SchemaDefinitionItemId);
+        if (schema == null)
+            return new ServiceResponse<ActionResponse>().SetErrorMessage("SCHEMA_NOT_FOUND").SetHttpStatusCode(404);
+
+        if (schema.SchemaType != SchemaType.Entity)
+            return new ServiceResponse<ActionResponse>().SetErrorMessage("SCHEMA_TYPE_NOT_INDEXABLE").SetHttpStatusCode(400);
+
+        var ineligibleFieldNames = request.Fields
+            .Where(f => !IsFieldIndexable(schema, f.FieldName))
+            .Select(f => f.FieldName)
+            .ToList();
+        if (ineligibleFieldNames.Count > 0)
+            return new ServiceResponse<ActionResponse>()
+                .SetErrorMessage($"FIELD_NOT_INDEXABLE: {string.Join(", ", ineligibleFieldNames)}")
+                .SetHttpStatusCode(400);
+
+        var existingIndexes = await GetIndexEntitiesAsync(schema.ItemId);
+        if (existingIndexes.Count >= MaxIndexesPerSchema)
+            return new ServiceResponse<ActionResponse>().SetErrorMessage("INDEX_LIMIT_REACHED").SetHttpStatusCode(400);
+
+        var keys = request.Fields
+            .Select(f => (f.FieldName, Direction: f.Direction == SortDirection.DESC ? -1 : 1))
+            .ToList();
+        var indexName = BuildIndexName(keys);
+
+        if (existingIndexes.Any(i => i.Name == indexName))
+            return new ServiceResponse<ActionResponse>().SetErrorMessage("INDEX_ALREADY_EXISTS").SetHttpStatusCode(409);
+
+        try
+        {
+            await _repository.CreateIndexAsync(schema.CollectionName, keys, request.IsUnique, indexName);
+        }
+        catch (MongoCommandException ex) when (ex.Code == 11000 || ex.Message.Contains("E11000", StringComparison.OrdinalIgnoreCase))
+        {
+            return new ServiceResponse<ActionResponse>().SetErrorMessage("UNIQUE_INDEX_CONFLICT").SetHttpStatusCode(409);
+        }
+
+        var indexDefinition = new SchemaIndexDefinition
+        {
+            SchemaDefinitionItemId = schema.ItemId,
+            Name = indexName,
+            IsUnique = request.IsUnique,
+            Fields = keys.Select(k => new IndexFieldSpec { FieldName = k.FieldName, Direction = k.Direction }).ToList()
+        };
+        var inserted = await _repository.InsertAsync(indexDefinition);
+        await _schemaChangeLogService.CreateSchemaChangeLogAsync(schema.ItemId, SchemaChangeType.SchemaIndexCreate);
+
+        return new ServiceResponse<ActionResponse>().SetSuccess(new ActionResponse { Acknowledged = true, ItemId = inserted.ItemId });
+    }
+
+    public async Task<ServiceResponse<SchemaIndexListResponse>> GetIndexesAsync(string schemaDefinitionItemId)
+    {
+        var schema = await _repository.GetItemAsync<SchemaDefinition>(schemaDefinitionItemId);
+        if (schema == null)
+            return new ServiceResponse<SchemaIndexListResponse>().SetErrorMessage("SCHEMA_NOT_FOUND").SetHttpStatusCode(404);
+
+        var indexes = await GetIndexEntitiesAsync(schema.ItemId);
+        var response = new SchemaIndexListResponse { Indexes = indexes.Select(MapToResponse).ToList() };
+        return new ServiceResponse<SchemaIndexListResponse>().SetSuccess(response);
+    }
+
+    public async Task<ServiceResponse<ActionResponse>> DeleteIndexAsync(string itemId)
+    {
+        var indexDefinition = await _repository.GetItemAsync<SchemaIndexDefinition>(itemId);
+        if (indexDefinition == null)
+            return new ServiceResponse<ActionResponse>().SetErrorMessage("INDEX_NOT_FOUND").SetHttpStatusCode(404);
+
+        var schema = await _repository.GetItemAsync<SchemaDefinition>(indexDefinition.SchemaDefinitionItemId);
+        if (schema != null)
+            await _repository.DropIndexAsync(schema.CollectionName, indexDefinition.Name);
+
+        var filter = Builders<SchemaIndexDefinition>.Filter.Eq(x => x.ItemId, indexDefinition.ItemId);
+        await _repository.DeleteAsync(filter);
+        await _schemaChangeLogService.CreateSchemaChangeLogAsync(indexDefinition.SchemaDefinitionItemId, SchemaChangeType.SchemaIndexDelete);
+
+        return new ServiceResponse<ActionResponse>().SetSuccess(new ActionResponse { Acknowledged = true, ItemId = indexDefinition.ItemId });
+    }
+
+    /// <summary>
+    /// Eligible fields mirror the existing IsUniqueData filter in MutationService, minus its
+    /// array exclusion: this feature explicitly supports multikey (array) indexes, only
+    /// reference fields and non-scalar types are excluded.
+    /// </summary>
+    private static bool IsFieldIndexable(SchemaDefinition schema, string fieldName)
+    {
+        var field = schema.Fields.FirstOrDefault(f => f.Name == fieldName);
+        return field != null && !field.IsReferenceField && GraphQlTypeHelper.IsScalar(field.Type);
+    }
+
+    private static string BuildIndexName(List<(string FieldName, int Direction)> keys) =>
+        string.Join("_", keys.Select(k => $"{k.FieldName}_{k.Direction}"));
+
+    private async Task<List<SchemaIndexDefinition>> GetIndexEntitiesAsync(string schemaDefinitionItemId)
+    {
+        var filter = new BsonDocument(nameof(SchemaIndexDefinition.SchemaDefinitionItemId), schemaDefinitionItemId);
+        return await _repository.GetItemsAsync<SchemaIndexDefinition>(filter, null, null, 0, 1000);
+    }
+
+    private static SchemaIndexResponse MapToResponse(SchemaIndexDefinition index) => new()
+    {
+        ItemId = index.ItemId,
+        Name = index.Name,
+        IsUnique = index.IsUnique,
+        CreatedDate = index.CreatedDate,
+        Fields = index.Fields.Select(f => new IndexFieldResponse
+        {
+            FieldName = f.FieldName,
+            Direction = f.Direction < 0 ? SortDirection.DESC : SortDirection.ASC
+        }).ToList()
+    };
+}

--- a/server/DataGateway.DomainService/Validators/CreateSchemaIndexRequestValidator.cs
+++ b/server/DataGateway.DomainService/Validators/CreateSchemaIndexRequestValidator.cs
@@ -1,0 +1,30 @@
+using FluentValidation;
+using DataGateway.DomainService.Models;
+
+namespace DataGateway.DomainService.Validators;
+
+public class CreateSchemaIndexRequestValidator : AbstractValidator<CreateSchemaIndexRequest>
+{
+    private const string SchemaDefinitionItemIdRequired = "SchemaDefinitionItemId_Is_Required.";
+    private const string InvalidIndexFields = "INVALID_INDEX_FIELDS";
+    private const string FieldNameRequired = "Field_Name_Is_Required.";
+
+    public CreateSchemaIndexRequestValidator()
+    {
+        RuleFor(x => x.SchemaDefinitionItemId)
+            .NotEmpty().WithMessage(SchemaDefinitionItemIdRequired);
+
+        RuleFor(x => x.Fields)
+            .NotNull().WithMessage(InvalidIndexFields)
+            .Must(fields => fields is not null && fields.Count > 0 && fields.Count <= 10)
+            .WithMessage(InvalidIndexFields)
+            .Must(fields => fields is null || fields.Select(f => f.FieldName).Distinct().Count() == fields.Count)
+            .WithMessage(InvalidIndexFields);
+
+        RuleForEach(x => x.Fields)
+            .ChildRules(field =>
+            {
+                field.RuleFor(f => f.FieldName).NotEmpty().WithMessage(FieldNameRequired);
+            });
+    }
+}

--- a/server/XUnitTest/Api/DataGatewayControllerTests.cs
+++ b/server/XUnitTest/Api/DataGatewayControllerTests.cs
@@ -126,6 +126,41 @@ public class DataGatewayControllerTests
         Status(await controller.DeleteSchemaDefinitionAsync("")).Should().Be(400);
     }
 
+    // ---------------- SchemaIndexController ----------------
+
+    [Fact]
+    public async Task SchemaIndex_Get_ValidatesAndDelegates()
+    {
+        var svc = new Mock<ISchemaIndexService>();
+        svc.Setup(s => s.GetIndexesAsync("schema-1"))
+            .ReturnsAsync(new ServiceResponse<SchemaIndexListResponse>().SetSuccess(new SchemaIndexListResponse()));
+        var controller = new SchemaIndexController(svc.Object);
+
+        Status(await controller.GetSchemaIndexes("schema-1")).Should().Be(200);
+        Status(await controller.GetSchemaIndexes("")).Should().Be(400);
+    }
+
+    [Fact]
+    public async Task SchemaIndex_Create_Delegates()
+    {
+        var svc = new Mock<ISchemaIndexService>();
+        svc.Setup(s => s.CreateIndexAsync(It.IsAny<CreateSchemaIndexRequest>())).ReturnsAsync(Ok());
+        var controller = new SchemaIndexController(svc.Object);
+
+        Status(await controller.CreateSchemaIndex(new CreateSchemaIndexRequest())).Should().Be(200);
+    }
+
+    [Fact]
+    public async Task SchemaIndex_Delete_ValidatesAndDelegates()
+    {
+        var svc = new Mock<ISchemaIndexService>();
+        svc.Setup(s => s.DeleteIndexAsync("idx-1")).ReturnsAsync(Ok());
+        var controller = new SchemaIndexController(svc.Object);
+
+        Status(await controller.DeleteSchemaIndex("idx-1")).Should().Be(200);
+        Status(await controller.DeleteSchemaIndex("")).Should().Be(400);
+    }
+
     // ---------------- DataValidationController ----------------
 
     [Fact]

--- a/server/XUnitTest/DataGateway/SchemaIndexRepositoryTests.cs
+++ b/server/XUnitTest/DataGateway/SchemaIndexRepositoryTests.cs
@@ -1,0 +1,97 @@
+using Blocks.Genesis;
+using DataGateway.DomainService.Repositories;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Moq;
+using XUnitTest.Infrastructure;
+
+namespace XUnitTest.DataGateway;
+
+/// <summary>
+/// Exercises DbRepository's CreateIndexAsync/DropIndexAsync against a real (ephemeral) MongoDB
+/// instance. A mocked IDbRepository can assert the shape of a call, but only a real server can
+/// prove an index actually gets built, enforces uniqueness, preserves compound field order, and
+/// rejects a unique build over pre-existing duplicate data.
+/// </summary>
+[Collection("Mongo")]
+public class SchemaIndexRepositoryTests
+{
+    private const string CollectionName = "Customers";
+    private readonly IMongoDatabase _db;
+    private readonly DbRepository _repository;
+
+    public SchemaIndexRepositoryTests(MongoFixture fixture)
+    {
+        _db = fixture.CreateDatabase();
+
+        var contextProvider = new Mock<IDbContextProvider>();
+        contextProvider.Setup(p => p.GetDatabase()).Returns(_db);
+
+        _repository = new DbRepository(contextProvider.Object, new Mock<IBlocksSecret>().Object);
+    }
+
+    private async Task<List<BsonDocument>> ListIndexesAsync() =>
+        await (await _db.GetCollection<BsonDocument>(CollectionName).Indexes.ListAsync()).ToListAsync();
+
+    [Fact]
+    public async Task CreateIndexAsync_SingleField_CreatesAscendingIndex()
+    {
+        var result = await _repository.CreateIndexAsync(CollectionName, new() { ("email", 1) }, isUnique: false, indexName: "email_1");
+
+        result.Acknowledged.Should().BeTrue();
+        var indexes = await ListIndexesAsync();
+        indexes.Should().Contain(i => i["name"] == "email_1" && i["key"]["email"] == 1);
+    }
+
+    [Fact]
+    public async Task CreateIndexAsync_Compound_PreservesFieldOrderAndDirection()
+    {
+        await _repository.CreateIndexAsync(CollectionName, new() { ("lastName", 1), ("age", -1) }, isUnique: false, indexName: "lastName_1_age_-1");
+
+        var indexes = await ListIndexesAsync();
+        var index = indexes.Single(i => i["name"] == "lastName_1_age_-1");
+        var keyNames = index["key"].AsBsonDocument.Names.ToList();
+        keyNames.Should().Equal("lastName", "age");
+        index["key"]["lastName"].Should().Be(1);
+        index["key"]["age"].Should().Be(-1);
+    }
+
+    [Fact]
+    public async Task CreateIndexAsync_Unique_EnforcesUniquenessOnFutureInserts()
+    {
+        await _repository.CreateIndexAsync(CollectionName, new() { ("email", 1) }, isUnique: true, indexName: "email_1");
+        var collection = _db.GetCollection<BsonDocument>(CollectionName);
+        await collection.InsertOneAsync(new BsonDocument { { "email", "a@x.com" } });
+
+        var act = async () => await collection.InsertOneAsync(new BsonDocument { { "email", "a@x.com" } });
+
+        await act.Should().ThrowAsync<MongoWriteException>();
+    }
+
+    [Fact]
+    public async Task CreateIndexAsync_UniqueOverExistingDuplicates_ThrowsAndBuildsNoIndex()
+    {
+        var collection = _db.GetCollection<BsonDocument>(CollectionName);
+        await collection.InsertOneAsync(new BsonDocument { { "email", "dup@x.com" } });
+        await collection.InsertOneAsync(new BsonDocument { { "email", "dup@x.com" } });
+
+        var act = async () => await _repository.CreateIndexAsync(CollectionName, new() { ("email", 1) }, isUnique: true, indexName: "email_1");
+
+        await act.Should().ThrowAsync<MongoCommandException>();
+        var indexes = await ListIndexesAsync();
+        indexes.Should().NotContain(i => i["name"] == "email_1");
+    }
+
+    [Fact]
+    public async Task DropIndexAsync_RemovesThePreviouslyCreatedIndex()
+    {
+        await _repository.CreateIndexAsync(CollectionName, new() { ("email", 1) }, isUnique: false, indexName: "email_1");
+
+        var result = await _repository.DropIndexAsync(CollectionName, "email_1");
+
+        result.Acknowledged.Should().BeTrue();
+        var indexes = await ListIndexesAsync();
+        indexes.Should().NotContain(i => i["name"] == "email_1");
+    }
+}

--- a/server/XUnitTest/DataGateway/Services/SchemaDefinitionServiceTests.cs
+++ b/server/XUnitTest/DataGateway/Services/SchemaDefinitionServiceTests.cs
@@ -36,6 +36,8 @@ public class SchemaDefinitionServiceTests
         // reference helper resolves nested references; keep them absent by default
         _repo.Setup(r => r.GetItemAsync<SchemaDefinition>(It.IsAny<FilterDefinition<SchemaDefinition>>(), "")).ReturnsAsync((SchemaDefinition?)null);
         _repo.Setup(r => r.GetItemsAsync<SchemaDefinition>(It.IsAny<FilterDefinition<BsonDocument>>(), null, null, 0, 100, "")).ReturnsAsync(new List<SchemaDefinition>());
+        // no schema has any index by default; SaveFieldDefinitionAsync's field-deletion guard checks this
+        _repo.Setup(r => r.GetItemsAsync<SchemaIndexDefinition>(It.IsAny<FilterDefinition<BsonDocument>>(), null, null, 0, 1000, "")).ReturnsAsync(new List<SchemaIndexDefinition>());
         _repo.Setup(r => r.InsertAsync(It.IsAny<SchemaDefinition>(), "")).ReturnsAsync((SchemaDefinition s, string _) => s);
         _repo.Setup(r => r.UpdateAsync(It.IsAny<SchemaDefinition>(), "")).ReturnsAsync(new ActionResponse { Acknowledged = true });
 
@@ -139,6 +141,35 @@ public class SchemaDefinitionServiceTests
         schema.Fields.Should().NotContain(f => f.Name == "Old");
         schema.Fields.First(f => f.Name == "Keep").Type.Should().Be("Int");
         schema.Fields.Should().Contain(f => f.Name == "New");
+    }
+
+    [Fact]
+    public async Task SaveFieldDefinition_DeletingFieldUsedByIndex_Returns400AndLeavesFieldsUnchanged()
+    {
+        var schema = new SchemaDefinition
+        {
+            ItemId = "1",
+            SchemaType = SchemaType.Entity,
+            Fields = new() { new FieldDefinition { Name = "email", Type = "String" } }
+        };
+        _repo.Setup(r => r.GetItemAsync<SchemaDefinition>(It.IsAny<string>(), "")).ReturnsAsync(schema);
+        _repo.Setup(r => r.GetItemsAsync<SchemaIndexDefinition>(It.IsAny<FilterDefinition<BsonDocument>>(), null, null, 0, 1000, ""))
+            .ReturnsAsync(new List<SchemaIndexDefinition>
+            {
+                new() { Name = "email_1", SchemaDefinitionItemId = "1", Fields = new() { new IndexFieldSpec { FieldName = "email", Direction = 1 } } }
+            });
+
+        var result = await _service.SaveFieldDefinitionAsync(new SaveFieldDefinitionRequest
+        {
+            SchemaDefinitionItemId = "1",
+            DeletableFieldNames = new[] { "email" },
+            Fields = new()
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.HttpStatusCode.Should().Be(400);
+        result.Message.Should().Contain("email_1");
+        schema.Fields.Should().Contain(f => f.Name == "email", "the field must stay untouched when its deletion is rejected");
     }
 
     [Fact]

--- a/server/XUnitTest/DataGateway/Services/SchemaIndexServiceTests.cs
+++ b/server/XUnitTest/DataGateway/Services/SchemaIndexServiceTests.cs
@@ -1,0 +1,295 @@
+using DataGateway.DomainService.Entities;
+using DataGateway.DomainService.Models;
+using DataGateway.DomainService.Models.Responses;
+using DataGateway.DomainService.Repositories;
+using DataGateway.DomainService.Services;
+using DataGateway.DomainService.Validators;
+using FluentAssertions;
+using FluentValidation.Results;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Moq;
+using XUnitTest.Infrastructure;
+using SortDirection = DataGateway.DomainService.Models.SortDirection;
+
+namespace XUnitTest.DataGateway.Services;
+
+/// <summary>
+/// Validation/business-rule paths for SchemaIndexService using a mocked IDbRepository.
+/// Real MongoDB index creation, uniqueness enforcement, and field-order preservation are
+/// covered separately against a real (ephemeral) Mongo instance, since a mock can't prove those.
+/// </summary>
+[Collection("ContextSerial")]
+public class SchemaIndexServiceTests
+{
+    private readonly Mock<IDbRepository> _repo = new();
+    private readonly Mock<IRequestValidator> _validator = new();
+    private readonly Mock<ISchemaChangeLogService> _changeLog = new();
+    private readonly SchemaIndexService _service;
+
+    public SchemaIndexServiceTests()
+    {
+        BlocksTestContext.Set();
+        _validator.Setup(v => v.ValidateAsync(It.IsAny<CreateSchemaIndexRequest>())).ReturnsAsync(new ValidationResult());
+        _repo.Setup(r => r.GetItemsAsync<SchemaIndexDefinition>(It.IsAny<FilterDefinition<BsonDocument>>(), null, null, 0, 1000, ""))
+            .ReturnsAsync(new List<SchemaIndexDefinition>());
+        _service = new SchemaIndexService(_repo.Object, _validator.Object, _changeLog.Object);
+    }
+
+    private static SchemaDefinition EntitySchema(string itemId = "schema-1", string collectionName = "Customers") => new()
+    {
+        ItemId = itemId,
+        SchemaType = SchemaType.Entity,
+        CollectionName = collectionName,
+        Fields = new()
+        {
+            new FieldDefinition { Name = "email", Type = "String" },
+            new FieldDefinition { Name = "lastName", Type = "String" },
+            new FieldDefinition { Name = "age", Type = "Int" },
+            new FieldDefinition { Name = "tags", Type = "String", IsArray = true },
+            new FieldDefinition { Name = "manager", Type = "Person", IsReferenceField = true },
+        }
+    };
+
+    [Fact]
+    public async Task CreateIndex_SchemaNotFound_Returns404()
+    {
+        _repo.Setup(r => r.GetItemAsync<SchemaDefinition>("missing", "")).ReturnsAsync((SchemaDefinition?)null);
+
+        var result = await _service.CreateIndexAsync(new CreateSchemaIndexRequest
+        {
+            SchemaDefinitionItemId = "missing",
+            Fields = new() { new IndexFieldRequest { FieldName = "email" } }
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.HttpStatusCode.Should().Be(404);
+        result.Message.Should().Be("SCHEMA_NOT_FOUND");
+    }
+
+    [Fact]
+    public async Task CreateIndex_DtoSchema_Returns400()
+    {
+        var schema = EntitySchema();
+        schema.SchemaType = SchemaType.Dto;
+        _repo.Setup(r => r.GetItemAsync<SchemaDefinition>("schema-1", "")).ReturnsAsync(schema);
+
+        var result = await _service.CreateIndexAsync(new CreateSchemaIndexRequest
+        {
+            SchemaDefinitionItemId = "schema-1",
+            Fields = new() { new IndexFieldRequest { FieldName = "email" } }
+        });
+
+        result.HttpStatusCode.Should().Be(400);
+        result.Message.Should().Be("SCHEMA_TYPE_NOT_INDEXABLE");
+    }
+
+    [Theory]
+    [InlineData("doesNotExist")]
+    [InlineData("manager")]
+    public async Task CreateIndex_IneligibleField_Returns400(string fieldName)
+    {
+        _repo.Setup(r => r.GetItemAsync<SchemaDefinition>("schema-1", "")).ReturnsAsync(EntitySchema());
+
+        var result = await _service.CreateIndexAsync(new CreateSchemaIndexRequest
+        {
+            SchemaDefinitionItemId = "schema-1",
+            Fields = new() { new IndexFieldRequest { FieldName = fieldName } }
+        });
+
+        result.HttpStatusCode.Should().Be(400);
+        result.Message.Should().StartWith("FIELD_NOT_INDEXABLE");
+    }
+
+    [Fact]
+    public async Task CreateIndex_ArrayField_IsEligible()
+    {
+        _repo.Setup(r => r.GetItemAsync<SchemaDefinition>("schema-1", "")).ReturnsAsync(EntitySchema());
+        _repo.Setup(r => r.CreateIndexAsync("Customers", It.IsAny<List<(string, int)>>(), false, "tags_1", ""))
+            .ReturnsAsync(new ActionResponse { Acknowledged = true });
+        _repo.Setup(r => r.InsertAsync(It.IsAny<SchemaIndexDefinition>(), ""))
+            .ReturnsAsync((SchemaIndexDefinition d, string _) => { d.ItemId = "idx-1"; return d; });
+
+        var result = await _service.CreateIndexAsync(new CreateSchemaIndexRequest
+        {
+            SchemaDefinitionItemId = "schema-1",
+            Fields = new() { new IndexFieldRequest { FieldName = "tags" } }
+        });
+
+        result.IsSuccess.Should().BeTrue("array (multikey) fields are explicitly eligible for indexing");
+        result.Data!.ItemId.Should().Be("idx-1");
+    }
+
+    [Fact]
+    public async Task CreateIndex_IndexLimitReached_Returns400()
+    {
+        _repo.Setup(r => r.GetItemAsync<SchemaDefinition>("schema-1", "")).ReturnsAsync(EntitySchema());
+        var fifteenIndexes = Enumerable.Range(0, 15)
+            .Select(i => new SchemaIndexDefinition { Name = $"idx_{i}", SchemaDefinitionItemId = "schema-1" })
+            .ToList();
+        _repo.Setup(r => r.GetItemsAsync<SchemaIndexDefinition>(It.IsAny<FilterDefinition<BsonDocument>>(), null, null, 0, 1000, ""))
+            .ReturnsAsync(fifteenIndexes);
+
+        var result = await _service.CreateIndexAsync(new CreateSchemaIndexRequest
+        {
+            SchemaDefinitionItemId = "schema-1",
+            Fields = new() { new IndexFieldRequest { FieldName = "email" } }
+        });
+
+        result.HttpStatusCode.Should().Be(400);
+        result.Message.Should().Be("INDEX_LIMIT_REACHED");
+    }
+
+    [Fact]
+    public async Task CreateIndex_DuplicateCombination_Returns409()
+    {
+        _repo.Setup(r => r.GetItemAsync<SchemaDefinition>("schema-1", "")).ReturnsAsync(EntitySchema());
+        _repo.Setup(r => r.GetItemsAsync<SchemaIndexDefinition>(It.IsAny<FilterDefinition<BsonDocument>>(), null, null, 0, 1000, ""))
+            .ReturnsAsync(new List<SchemaIndexDefinition> { new() { Name = "email_1", SchemaDefinitionItemId = "schema-1" } });
+
+        var result = await _service.CreateIndexAsync(new CreateSchemaIndexRequest
+        {
+            SchemaDefinitionItemId = "schema-1",
+            Fields = new() { new IndexFieldRequest { FieldName = "email", Direction = SortDirection.ASC } }
+        });
+
+        result.HttpStatusCode.Should().Be(409);
+        result.Message.Should().Be("INDEX_ALREADY_EXISTS");
+    }
+
+    [Fact]
+    public async Task CreateIndex_Compound_BuildsOrderedKeysAndName()
+    {
+        _repo.Setup(r => r.GetItemAsync<SchemaDefinition>("schema-1", "")).ReturnsAsync(EntitySchema());
+        List<(string FieldName, int Direction)>? capturedKeys = null;
+        _repo.Setup(r => r.CreateIndexAsync("Customers", It.IsAny<List<(string, int)>>(), true, "lastName_1_age_-1", ""))
+            .Callback<string, List<(string, int)>, bool, string, string>((_, keys, _, _, _) => capturedKeys = keys)
+            .ReturnsAsync(new ActionResponse { Acknowledged = true });
+        _repo.Setup(r => r.InsertAsync(It.IsAny<SchemaIndexDefinition>(), ""))
+            .ReturnsAsync((SchemaIndexDefinition d, string _) => { d.ItemId = "idx-1"; return d; });
+
+        var result = await _service.CreateIndexAsync(new CreateSchemaIndexRequest
+        {
+            SchemaDefinitionItemId = "schema-1",
+            IsUnique = true,
+            Fields = new()
+            {
+                new IndexFieldRequest { FieldName = "lastName", Direction = SortDirection.ASC },
+                new IndexFieldRequest { FieldName = "age", Direction = SortDirection.DESC },
+            }
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        capturedKeys.Should().Equal(("lastName", 1), ("age", -1));
+        _changeLog.Verify(c => c.CreateSchemaChangeLogAsync("schema-1", SchemaChangeType.SchemaIndexCreate), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateIndex_MongoDuplicateKeyOnUniqueBuild_Returns409AndPersistsNothing()
+    {
+        _repo.Setup(r => r.GetItemAsync<SchemaDefinition>("schema-1", "")).ReturnsAsync(EntitySchema());
+        _repo.Setup(r => r.CreateIndexAsync("Customers", It.IsAny<List<(string, int)>>(), true, "email_1", ""))
+            .ThrowsAsync(new MongoCommandException(
+                new MongoDB.Driver.Core.Connections.ConnectionId(new MongoDB.Driver.Core.Servers.ServerId(new MongoDB.Driver.Core.Clusters.ClusterId(), new System.Net.DnsEndPoint("localhost", 27017))),
+                "E11000 duplicate key error collection",
+                new BsonDocument(),
+                new BsonDocument("code", 11000)));
+
+        var result = await _service.CreateIndexAsync(new CreateSchemaIndexRequest
+        {
+            SchemaDefinitionItemId = "schema-1",
+            IsUnique = true,
+            Fields = new() { new IndexFieldRequest { FieldName = "email" } }
+        });
+
+        result.HttpStatusCode.Should().Be(409);
+        result.Message.Should().Be("UNIQUE_INDEX_CONFLICT");
+        _repo.Verify(r => r.InsertAsync(It.IsAny<SchemaIndexDefinition>(), ""), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetIndexes_SchemaNotFound_Returns404()
+    {
+        _repo.Setup(r => r.GetItemAsync<SchemaDefinition>("missing", "")).ReturnsAsync((SchemaDefinition?)null);
+
+        var result = await _service.GetIndexesAsync("missing");
+
+        result.HttpStatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task GetIndexes_NoIndexes_ReturnsEmptyList()
+    {
+        _repo.Setup(r => r.GetItemAsync<SchemaDefinition>("schema-1", "")).ReturnsAsync(EntitySchema());
+
+        var result = await _service.GetIndexesAsync("schema-1");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Data!.Indexes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetIndexes_WithExistingIndexes_MapsEveryFieldOfTheResponse()
+    {
+        _repo.Setup(r => r.GetItemAsync<SchemaDefinition>("schema-1", "")).ReturnsAsync(EntitySchema());
+        var created = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        _repo.Setup(r => r.GetItemsAsync<SchemaIndexDefinition>(It.IsAny<FilterDefinition<BsonDocument>>(), null, null, 0, 1000, ""))
+            .ReturnsAsync(new List<SchemaIndexDefinition>
+            {
+                new()
+                {
+                    ItemId = "idx-1",
+                    Name = "lastName_1_age_-1",
+                    IsUnique = true,
+                    CreatedDate = created,
+                    Fields = new()
+                    {
+                        new IndexFieldSpec { FieldName = "lastName", Direction = 1 },
+                        new IndexFieldSpec { FieldName = "age", Direction = -1 },
+                    }
+                }
+            });
+
+        var result = await _service.GetIndexesAsync("schema-1");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Data!.Indexes.Should().ContainSingle();
+        var index = result.Data!.Indexes[0];
+        index.ItemId.Should().Be("idx-1");
+        index.Name.Should().Be("lastName_1_age_-1");
+        index.IsUnique.Should().BeTrue();
+        index.CreatedDate.Should().Be(created);
+        index.Fields.Should().BeEquivalentTo(new[]
+        {
+            new IndexFieldResponse { FieldName = "lastName", Direction = SortDirection.ASC },
+            new IndexFieldResponse { FieldName = "age", Direction = SortDirection.DESC }
+        }, options => options.WithStrictOrdering());
+    }
+
+    [Fact]
+    public async Task DeleteIndex_NotFound_Returns404()
+    {
+        _repo.Setup(r => r.GetItemAsync<SchemaIndexDefinition>("missing", "")).ReturnsAsync((SchemaIndexDefinition?)null);
+
+        var result = await _service.DeleteIndexAsync("missing");
+
+        result.HttpStatusCode.Should().Be(404);
+        result.Message.Should().Be("INDEX_NOT_FOUND");
+    }
+
+    [Fact]
+    public async Task DeleteIndex_Existing_DropsMongoIndexAndDeletesMetadata()
+    {
+        var index = new SchemaIndexDefinition { ItemId = "idx-1", SchemaDefinitionItemId = "schema-1", Name = "email_1" };
+        _repo.Setup(r => r.GetItemAsync<SchemaIndexDefinition>("idx-1", "")).ReturnsAsync(index);
+        _repo.Setup(r => r.GetItemAsync<SchemaDefinition>("schema-1", "")).ReturnsAsync(EntitySchema());
+        _repo.Setup(r => r.DropIndexAsync("Customers", "email_1", "")).ReturnsAsync(new ActionResponse { Acknowledged = true });
+        _repo.Setup(r => r.DeleteAsync(It.IsAny<FilterDefinition<SchemaIndexDefinition>>(), "")).ReturnsAsync(new ActionResponse { Acknowledged = true });
+
+        var result = await _service.DeleteIndexAsync("idx-1");
+
+        result.IsSuccess.Should().BeTrue();
+        _repo.Verify(r => r.DropIndexAsync("Customers", "email_1", ""), Times.Once);
+        _changeLog.Verify(c => c.CreateSchemaChangeLogAsync("schema-1", SchemaChangeType.SchemaIndexDelete), Times.Once);
+    }
+}

--- a/server/XUnitTest/DataGateway/Validators/CreateSchemaIndexRequestValidatorTests.cs
+++ b/server/XUnitTest/DataGateway/Validators/CreateSchemaIndexRequestValidatorTests.cs
@@ -1,0 +1,94 @@
+using DataGateway.DomainService.Models;
+using DataGateway.DomainService.Validators;
+using FluentAssertions;
+using SortDirection = DataGateway.DomainService.Models.SortDirection;
+
+namespace XUnitTest.DataGateway.Validators;
+
+public class CreateSchemaIndexRequestValidatorTests
+{
+    private readonly CreateSchemaIndexRequestValidator _validator = new();
+
+    [Fact]
+    public void Valid_SingleField_Passes()
+    {
+        var result = _validator.Validate(new CreateSchemaIndexRequest
+        {
+            SchemaDefinitionItemId = "schema-1",
+            Fields = new() { new IndexFieldRequest { FieldName = "email", Direction = SortDirection.ASC } }
+        });
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void MissingSchemaDefinitionItemId_Fails()
+    {
+        var result = _validator.Validate(new CreateSchemaIndexRequest
+        {
+            SchemaDefinitionItemId = "",
+            Fields = new() { new IndexFieldRequest { FieldName = "email" } }
+        });
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ZeroFields_FailsWithInvalidIndexFields()
+    {
+        var result = _validator.Validate(new CreateSchemaIndexRequest
+        {
+            SchemaDefinitionItemId = "schema-1",
+            Fields = new()
+        });
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage == "INVALID_INDEX_FIELDS");
+    }
+
+    [Fact]
+    public void MoreThanTenFields_FailsWithInvalidIndexFields()
+    {
+        var fields = Enumerable.Range(0, 11).Select(i => new IndexFieldRequest { FieldName = $"f{i}" }).ToList();
+
+        var result = _validator.Validate(new CreateSchemaIndexRequest
+        {
+            SchemaDefinitionItemId = "schema-1",
+            Fields = fields
+        });
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage == "INVALID_INDEX_FIELDS");
+    }
+
+    [Fact]
+    public void DuplicateFieldNameWithinRequest_FailsWithInvalidIndexFields()
+    {
+        var result = _validator.Validate(new CreateSchemaIndexRequest
+        {
+            SchemaDefinitionItemId = "schema-1",
+            Fields = new()
+            {
+                new IndexFieldRequest { FieldName = "email" },
+                new IndexFieldRequest { FieldName = "email" },
+            }
+        });
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage == "INVALID_INDEX_FIELDS");
+    }
+
+    [Fact]
+    public void TenFields_IsAtTheAllowedMax_Passes()
+    {
+        var fields = Enumerable.Range(0, 10).Select(i => new IndexFieldRequest { FieldName = $"f{i}" }).ToList();
+
+        var result = _validator.Validate(new CreateSchemaIndexRequest
+        {
+            SchemaDefinitionItemId = "schema-1",
+            Fields = fields
+        });
+
+        result.IsValid.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
- Added SchemaIndexController for managing MongoDB indexes on schemas, including endpoints for creating, retrieving, and deleting indexes.
- Introduced SchemaIndexService to handle business logic for index operations, including validation and interaction with the database.
- Created models for index requests and responses, including CreateSchemaIndexRequest and SchemaIndexResponse.
- Developed validators for index creation requests to enforce business rules.
- Implemented utility functions for mapping error messages related to index operations.
- Added comprehensive unit tests for the SchemaIndexService and validators to ensure correct behavior and error handling.
- Established integration tests for the DbRepository to validate index creation and deletion against a real MongoDB instance.